### PR TITLE
chore: deprecate DODOchain, GM Network, and Xterio AVS

### DIFF
--- a/avs/DODOchainMach/metadata.json
+++ b/avs/DODOchainMach/metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "DODOchain MACH (Powered by AltLayer)",
+    "name": "[Deprecated] DODOchain MACH (Powered by AltLayer)",
     "website": "https://www.dodochain.com/",
     "description": "DODOchain is an Omni-Trading Layer3, powered by the integration of Arbitrum, EigenLayer, and AltLayer. As a rollup-level liquidity layer, it connects Ethereum rollups and Bitcoin networks, consolidating liquidity into a single platform for seamless cross-chain trading. Leveraging its status as a Restaked Rollup, DODOchain offers decentralized verification and rapid finality, significantly enhancing both security and efficiency in the Omni-chain era.",
     "logo": "https://raw.githubusercontent.com/alt-research/eigendata/dev/avs/DODOchainMach/logo.png",

--- a/avs/GMNetworkMach/metadata.json
+++ b/avs/GMNetworkMach/metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "GM Network MACH (Powered by AltLayer)",
+    "name": "[Deprecated] GM Network MACH (Powered by AltLayer)",
     "website": "https://gmnetwork.ai/",
     "description": "GM Network is the first consumer AIoT network. The GM Network's modular ecosystem is designed to facilitate the large-scale adoption of AIoT (AI + IoT) by significantly reducing costs and barriers for developers. It consists of three primary layers: the Asset Layer, the Data Layer, and the User Layer.",
     "logo": "https://raw.githubusercontent.com/alt-research/eigendata/dev/avs/GMNetworkMach/logo.png",

--- a/avs/XterioMach/metadata.json
+++ b/avs/XterioMach/metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "Xterio Mach (Powered by AltLayer)",
+    "name": "[Deprecated] Xterio Mach (Powered by AltLayer)",
     "website": "https://xter.io/",
     "description": "Xterio is a Web3 game developer and publisher founded by veterans of the game industry. Our mission is to create deep and rich gaming experiences driven by player ownership. We create rich worlds, stories, and characters to bring you amazing experiences. We make games because we love them and strive to make every Xterio game memorable and FUN!",
     "logo": "https://raw.githubusercontent.com/alt-research/eigendata/dev/avs/XterioMach/logo.png",


### PR DESCRIPTION
## Summary
- Add [Deprecated] prefix to AVS names:
  - DODOchain MACH
  - GM Network MACH
  - Xterio Mach